### PR TITLE
Add Ruby 3.3 and Active Record 7.1 compatibility

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -16,7 +16,7 @@ jobs:
           bundler-cache: true
       - name: Install dependencies
         env:
-          ACTIVE_RECORD_VERSION: 7.0
+          ACTIVE_RECORD_VERSION: 7.1
         run: bundle install --jobs 3 --retry 3
       - name: Run tests
         run: bundle exec rubocop -D

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version: ["2.7.5", "3.0.3", "3.1.0", "3.2.0"]
-        active_record_version: ["6.0", "6.1", "7.0"]
+        active_record_version: ["6.0", "6.1", "7.0", "7.1"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.7.5", "3.0.3", "3.1.0", "3.2.0"]
+        ruby_version: ["2.7.5", "3.0.3", "3.1.0", "3.2.0", "3.3.0"]
         active_record_version: ["6.0", "6.1", "7.0", "7.1"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1.131.0
+        uses: ruby/setup-ruby@v1.177.0
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true

--- a/acts_as_hashids.gemspec
+++ b/acts_as_hashids.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ['>= 2.3.0', '< 3.3']
 
-  spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 7.1'
+  spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 8.0'
   spec.add_runtime_dependency 'hashids', '~> 1.0'
 
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.5'

--- a/acts_as_hashids.gemspec
+++ b/acts_as_hashids.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ['>= 2.3.0', '< 3.3']
+  spec.required_ruby_version = ['>= 2.3.0', '< 4.0']
 
   spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 8.0'
   spec.add_runtime_dependency 'hashids', '~> 1.0'


### PR DESCRIPTION
Adds support for Ruby 3.3 and Active Record 7.1, drawing from the pending PRs in the main repo:
* https://github.com/dtaniwaki/acts_as_hashids/pull/29
* https://github.com/dtaniwaki/acts_as_hashids/pull/26